### PR TITLE
gh-#120083: Fix an issue w/ Hovertip foreground color causing tooltip text not to render on Mac OS

### DIFF
--- a/Lib/idlelib/tooltip.py
+++ b/Lib/idlelib/tooltip.py
@@ -144,7 +144,7 @@ class OnHoverTooltipBase(TooltipBase):
 
 class Hovertip(OnHoverTooltipBase):
     "A tooltip that pops up when a mouse hovers over an anchor widget."
-    def __init__(self, anchor_widget, text, hover_delay=1000):
+    def __init__(self, anchor_widget, text, foreground="#000000", background="#ffffe0",  hover_delay=1000):
         """Create a text tooltip with a mouse hover delay.
 
         anchor_widget: the widget next to which the tooltip will be shown
@@ -156,10 +156,12 @@ class Hovertip(OnHoverTooltipBase):
         """
         super().__init__(anchor_widget, hover_delay=hover_delay)
         self.text = text
+        self.foreground = foreground
+        self.background = background
 
     def showcontents(self):
-        label = Label(self.tipwindow, text=self.text, justify=LEFT,
-                      background="#ffffe0", relief=SOLID, borderwidth=1)
+        label = Label(self.tipwindow, text=self.text, justify=LEFT, foreground=self.foreground,
+                      background=self.background, relief=SOLID, borderwidth=1)
         label.pack()
 
 


### PR DESCRIPTION
Fix an issue w/ Hovertip foreground color causing tooltip text not to render on Mac OS

Add params for `foreground` and `background` color to Hovertip.__init__()